### PR TITLE
Allow existing connections

### DIFF
--- a/lib/regrid.js
+++ b/lib/regrid.js
@@ -26,8 +26,12 @@ let ReGrid = function (connOpts, bucketOpts) {
   let conf = Object.assign({}, bucketOptions, bucketOpts)
   let fileTable = `${conf.bucketName}_files`
   let chunkTable = `${conf.bucketName}_chunks`
-
-  let r = require('rethinkdbdash')(Object.assign({silent: true}, connOpts))
+  
+  if(connOpts.r) {
+    let r = connOpts.r
+  } else {
+    let r = require('rethinkdbdash')(Object.assign({silent: true}, connOpts))
+  }
 
   let initBucket = Promise.coroutine(function *() {
     var promises = []


### PR DESCRIPTION
Allows regrid to use an existing instance of rethinkdbdash